### PR TITLE
Add build_flags in platformio to configure LMIC.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,13 @@ lib_deps =
 	adafruit/Adafruit SSD1306
 monitor_speed = 115200
 
+; configure LMIC
+build_flags =
+	-D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS
+	-D CFG_eu868=1
+	-D CFG_sx1276_radio=1
+	-D hal_init=LMICHAL_init
+
 ; change microcontroller
 board_build.mcu = esp32
 


### PR DESCRIPTION
Met deze wijziging wordt de configuratie van LMIC gedaan in de zogenaamde build flags in de platformio.ini file.
Daardoor hoef je niet langer handmatige wijzigingen toe te passen in de lmic_project_config.h file.

Ik heb dit getest door de sha1sum te laten berekenen van .pio/build/ttgo-lora32-v21/firmware.bin
De gebouwde firmware.bin file van deze patch is identiek aan degene die gebouwd wordt d.m.v. de handmatige wijzigingen.